### PR TITLE
Switch to QuantLib Date type

### DIFF
--- a/QuantScript/main/QuantScript.cpp
+++ b/QuantScript/main/QuantScript.cpp
@@ -17,8 +17,9 @@ template <class T>
 void test_product()
 {
 	string s = "X = 3";
-	map<Date, string> mapping = {{0, s}};
-	Product prod;
+        Date today(1, QuantLib::January, 2020);
+        map<Date, string> mapping = {{today, s}};
+        Product prod;
 	prod.parseEvents(mapping.begin(), mapping.end());
 	prod.indexVariables();
 	Debugger d;
@@ -87,10 +88,10 @@ template <class T>
 int evaluation_test()
 {
 	// Inputs
-	map<string, string> macros = {{"STRIKE", "650"}};
-	map<Date, string> events = {{360, "opt pays max(SPOT()-650,0)"}};
-
-	Date today = 0;
+        map<string, string> macros = {{"STRIKE", "650"}};
+        Date today(1, QuantLib::January, 2020);
+        Date eventDate = today + 360;
+        map<Date, string> events = {{eventDate, "opt pays max(SPOT()-650,0)"}};
 	T spot = 700, vol = 0.3, rate = 0.06;
 	unsigned numSim = 1;
 

--- a/QuantScript/models/models.h
+++ b/QuantScript/models/models.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <stdexcept>
 #include <map>
+#include <ql/time/daycounters/actual360.hpp>
 #include "nodes/nodes.h"
 
 namespace QuantScript
@@ -126,16 +127,17 @@ namespace QuantScript
 		const T &rate() { return myRate; }
 		const T &vol() { return myVol; }
 		// Initialize simulation dates
-		void initSimDates(const std::vector<Date> &simDates) override
-		{
-			myTime0 = simDates[0] == myToday;
-			// Fill array of times
-			for (auto dateIt = simDates.begin();
-				 dateIt != simDates.end();
-				 ++dateIt)
-			{
-				myTimes.push_back(double(*dateIt - myToday) / 360);
-			}
+                void initSimDates(const std::vector<Date> &simDates) override
+                {
+                        myTime0 = simDates[0] == myToday;
+                        QuantLib::Actual360 dc;
+                        // Fill array of times using QuantLib day count
+                        for (auto dateIt = simDates.begin();
+                             dateIt != simDates.end();
+                             ++dateIt)
+                        {
+                                myTimes.push_back(dc.yearFraction(myToday, *dateIt));
+                        }
 			myDt.resize(myTimes.size());
 			myDt[0] = myTimes[0];
 			for (size_t i = 1; i < myTimes.size(); ++i)

--- a/QuantScript/nodes/nodes.h
+++ b/QuantScript/nodes/nodes.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <cmath>
+#include <ql/time/date.hpp>
 
 namespace QuantScript
 {
@@ -11,7 +12,7 @@ namespace QuantScript
     class Visitor;
     class ConstVisitor;
 
-    using Date = int;
+    using Date = QuantLib::Date;
     using ExpressionTree = std::unique_ptr<Node>;
     using Statement = ExpressionTree;
     using Event = std::vector<Statement>;


### PR DESCRIPTION
## Summary
- use `QuantLib::Date` instead of `int` for dates
- compute year fractions with `QuantLib::Actual360`
- update examples to build QuantLib dates

## Testing
- `cmake ..` *(fails: could not find automatic)*

------
https://chatgpt.com/codex/tasks/task_e_683c4b6fdaa0832dbbdd20e462907b11